### PR TITLE
Add service objects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.1)
+    activesupport (4.2.5)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -15,14 +15,12 @@ GEM
       tzinfo (~> 1.1)
     ansi (1.5.0)
     builder (3.2.2)
-    celluloid (0.16.0)
-      timers (~> 4.0.0)
     coderay (1.1.0)
-    ffi (1.9.8)
+    ffi (1.9.10)
     formatador (0.2.5)
-    guard (2.12.5)
+    guard (2.13.0)
       formatador (>= 0.2.4)
-      listen (~> 2.7)
+      listen (>= 2.7, <= 4.0)
       lumberjack (~> 1.0)
       nenv (~> 0.1)
       notiffany (~> 0.0)
@@ -33,31 +31,29 @@ GEM
     guard-minitest (2.4.4)
       guard-compat (~> 1.2)
       minitest (>= 3.0)
-    hitimes (1.2.2)
     i18n (0.7.0)
-    json (1.8.2)
-    listen (2.10.0)
-      celluloid (~> 0.16.0)
+    json (1.8.3)
+    listen (3.0.5)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     lumberjack (1.0.9)
     method_source (0.8.2)
-    minitest (5.5.1)
-    minitest-reporters (1.0.11)
+    minitest (5.8.3)
+    minitest-reporters (1.1.7)
       ansi
       builder
       minitest (>= 5.0)
       ruby-progressbar
     nenv (0.2.0)
-    notiffany (0.0.6)
+    notiffany (0.0.8)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    pry (0.10.1)
+    pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rake (10.4.2)
-    rb-fsevent (0.9.4)
+    rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     ruby-progressbar (1.7.5)
@@ -65,8 +61,6 @@ GEM
     slop (3.6.0)
     thor (0.19.1)
     thread_safe (0.3.5)
-    timers (4.0.1)
-      hitimes
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
@@ -80,3 +74,6 @@ DEPENDENCIES
   minitest-reporters
   nform!
   rake
+
+BUNDLED WITH
+   1.10.6

--- a/lib/nform.rb
+++ b/lib/nform.rb
@@ -1,5 +1,3 @@
-require 'active_support'
-
 module NForm
   # A base error class for any NForm exceptions to extend
   Error = Class.new(StandardError)
@@ -18,3 +16,5 @@ require 'nform/builder'
 require 'nform/attributes'
 require 'nform/validations'
 require 'nform/coercions'
+require 'nform/form'
+require 'nform/service'

--- a/lib/nform/builder.rb
+++ b/lib/nform/builder.rb
@@ -1,4 +1,6 @@
+require 'nform/core_ext'
 require 'active_support/core_ext/string'
+
 module NForm
   class Builder
     include HTML

--- a/lib/nform/coercions.rb
+++ b/lib/nform/coercions.rb
@@ -1,3 +1,4 @@
+require 'nform/core_ext'
 require 'active_support/core_ext/hash'
 require 'active_support/core_ext/object'
 

--- a/lib/nform/core_ext.rb
+++ b/lib/nform/core_ext.rb
@@ -1,0 +1,12 @@
+require 'active_support'
+
+module NForm
+  module Hashable
+    # A convenience method for making a hash with the
+    # given methods on self as the keys and return for
+    # the given methods as the values
+    def hash_of(*keys)
+      keys.each.with_object({}){|k,h| h[k] = send(k) }
+    end
+  end
+end

--- a/lib/nform/form.rb
+++ b/lib/nform/form.rb
@@ -1,0 +1,44 @@
+require 'nform/core_ext'
+
+module NForm
+  class Form
+    extend NForm::Attributes
+    include NForm::Validations
+
+    def valid?
+      errors.clear
+      validate!
+      true
+    rescue ValidationError
+      false
+    end
+
+    def validate!
+      yield if block_given?
+      validation_error! if errors.any?
+    end
+
+    private
+    def validation_error!(hash={})
+      errors.merge(hash)
+      raise ValidationError.new(errors)
+    end
+  end
+
+  class ValidationError < Error
+    attr_reader :errors
+    def initialize(errors={})
+      @errors = errors
+    end
+
+    def message
+      "\nPlease correct the following errors:\n#{error_messages}"
+    end
+
+    def error_messages
+      if errors.any?
+        errors.map{|k,v| "#{k.to_s.humanize}: #{v}"}.join("\n")
+      end
+    end
+  end
+end

--- a/lib/nform/service.rb
+++ b/lib/nform/service.rb
@@ -1,0 +1,53 @@
+require 'nform/core_ext'
+
+module NForm
+  # Services expect valid input
+  # A service performs a single action
+  # A service should not accept unfiltered user input,
+  # but accept a form object when user input is required
+  class Service
+    include Hashable
+
+    attr_reader :form
+    def initialize(input)
+      @form = get_form(input)
+    end
+
+    def call
+      raise "Must be defined in subclass"
+    end
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    def self.form_class(klass=nil)
+      @@form_class = klass || const_get(:Form)
+    end
+
+    def self.form_object &block
+      form = Class.new(Form)
+      form.class_eval &block
+      const_set :Form, form
+    end
+
+    private
+    def get_form(input)
+      input.is_a?(@@form_class) ? input : @@form_class.new(input)
+    end
+
+    def error!(message)
+      raise ServiceError.new(message)
+    end
+
+    def validate!
+    end
+  end
+
+  class ServiceError < Error
+    attr_reader :message
+    def initialize(message="Unknown Error")
+      @message = message
+    end
+  end
+end

--- a/lib/nform/service.rb
+++ b/lib/nform/service.rb
@@ -25,12 +25,6 @@ module NForm
       @@form_class = klass || const_get(:Form)
     end
 
-    def self.form_object &block
-      form = Class.new(Form)
-      form.class_eval &block
-      const_set :Form, form
-    end
-
     private
     def get_form(input)
       input.is_a?(@@form_class) ? input : @@form_class.new(input)

--- a/test/nform/core_ext_test.rb
+++ b/test/nform/core_ext_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class HashableTester
+  include NForm::Hashable
+
+  def a
+    1
+  end
+
+  def b
+    2
+  end
+end
+
+describe NForm::Hashable do
+  it "should generate a hash from its own methods" do
+    h = HashableTester.new
+    assert_equal ({a:1,b:2}), h.hash_of(:a,:b)
+  end
+end

--- a/test/nform/form_test.rb
+++ b/test/nform/form_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class FormTest < NForm::Form
+  attribute :alpha, coerce: :to_integer, required: true
+  attribute :beta, coerce: :to_string, required: true
+  attribute :charlie
+
+  def validate!
+    validate_presence_of :alpha, :beta
+    errors[:alpha] = "Alpha must be greater than 10" unless alpha > 10
+    super
+  end
+end
+
+describe NForm::Form do
+  it "should init with required args" do
+    f = FormTest.new(alpha: 11, beta: "hello")
+    assert_equal true, f.valid?
+  end
+
+  it "should raise argument error without required args" do
+    assert_raises(ArgumentError) do
+      FormTest.new
+    end
+  end
+
+  it "should validate args" do
+    f = FormTest.new(alpha: 5, beta: "hello")
+    assert_equal false, f.valid?
+    assert_equal "Alpha must be greater than 10", f.errors[:alpha]
+  end
+end

--- a/test/nform/service_test.rb
+++ b/test/nform/service_test.rb
@@ -1,0 +1,136 @@
+require 'test_helper'
+require 'ostruct'
+
+class ServiceTest < NForm::Service
+  form_class OpenStruct
+
+  def call
+    validate!
+  end
+
+  private
+  def validate!
+    error! "'a' must be numeric" unless form.a.is_a?(Numeric)
+    error! "'b' must be numeric" unless form.b.is_a?(Numeric)
+  end
+end
+
+class EmbeddedFormTest < NForm::Service
+  class Form < NForm::Form
+    attribute :a, coerce: :to_integer, required: true
+    attribute :b, coerce: :to_integer, required: true
+
+    def validate!
+      validate_numericality_of :a, :b
+      super
+    end
+  end
+
+
+  def call
+    validate!
+  end
+
+  private
+  def validate!
+    form.validate!
+    super
+  end
+end
+
+class MetaFormTest < NForm::Service
+  form_object do
+    attribute :a, coerce: :to_integer, required: true
+    attribute :b, coerce: :to_integer, required: true
+
+    def validate!
+      validate_numericality_of :a, :b
+      super
+    end
+  end
+
+
+  def call
+    validate!
+  end
+
+  private
+  def validate!
+    form.validate!
+    super
+  end
+end
+
+describe "using form_class" do
+  it "should generate a service object instance" do
+    s = ServiceTest.new(a: 1, b: 2)
+    assert s.is_a?(ServiceTest)
+  end
+
+  it "should respond to call" do
+    s = ServiceTest.new(a: 1, b: 2)
+    assert_equal true, s.respond_to?(:call)
+  end
+
+  it "should generate instance and call in one step" do
+    input = {a:1,b:2}
+    s1 = ServiceTest.new(input)
+    assert_equal s1.call, ServiceTest.call(input)
+  end
+
+  it "should raise service errors" do
+    input = {a:'a',b:'b'}
+    err = assert_raises(NForm::ServiceError) do
+      ServiceTest.call(input)
+    end
+    assert_match /numeric/, err.message
+  end
+end
+
+describe "using embedded form" do
+  it "should generate a service object instance" do
+    s = EmbeddedFormTest.new(a: 1, b: 2)
+    assert s.is_a?(EmbeddedFormTest)
+  end
+
+  it "should respond to call" do
+    s = EmbeddedFormTest.new(a: 1, b: 2)
+    assert_equal true, s.respond_to?(:call)
+  end
+
+  it "should generate instance and call in one step" do
+    input = {a:1,b:2}
+    s1 = EmbeddedFormTest.new(input)
+    assert_equal s1.call, EmbeddedFormTest.call(input)
+  end
+
+  it "should raise argument errors" do
+    assert_raises(ArgumentError) do
+      EmbeddedFormTest.call()
+    end
+  end
+end
+
+describe "using meta form" do
+  it "should generate a service object instance" do
+    s = MetaFormTest.new(a: 1, b: 2)
+    assert s.is_a?(MetaFormTest)
+  end
+
+  it "should respond to call" do
+    s = MetaFormTest.new(a: 1, b: 2)
+    assert_equal true, s.respond_to?(:call)
+  end
+
+  it "should generate instance and call in one step" do
+    input = {a:1,b:2}
+    s1 = MetaFormTest.new(input)
+    assert_equal s1.call, MetaFormTest.call(input)
+  end
+
+  it "should raise argument errors" do
+    assert_raises(ArgumentError) do
+      MetaFormTest.call()
+    end
+  end
+end

--- a/test/nform/service_test.rb
+++ b/test/nform/service_test.rb
@@ -38,29 +38,6 @@ class EmbeddedFormTest < NForm::Service
   end
 end
 
-class MetaFormTest < NForm::Service
-  form_object do
-    attribute :a, coerce: :to_integer, required: true
-    attribute :b, coerce: :to_integer, required: true
-
-    def validate!
-      validate_numericality_of :a, :b
-      super
-    end
-  end
-
-
-  def call
-    validate!
-  end
-
-  private
-  def validate!
-    form.validate!
-    super
-  end
-end
-
 describe "using form_class" do
   it "should generate a service object instance" do
     s = ServiceTest.new(a: 1, b: 2)
@@ -107,30 +84,6 @@ describe "using embedded form" do
   it "should raise argument errors" do
     assert_raises(ArgumentError) do
       EmbeddedFormTest.call()
-    end
-  end
-end
-
-describe "using meta form" do
-  it "should generate a service object instance" do
-    s = MetaFormTest.new(a: 1, b: 2)
-    assert s.is_a?(MetaFormTest)
-  end
-
-  it "should respond to call" do
-    s = MetaFormTest.new(a: 1, b: 2)
-    assert_equal true, s.respond_to?(:call)
-  end
-
-  it "should generate instance and call in one step" do
-    input = {a:1,b:2}
-    s1 = MetaFormTest.new(input)
-    assert_equal s1.call, MetaFormTest.call(input)
-  end
-
-  it "should raise argument errors" do
-    assert_raises(ArgumentError) do
-      MetaFormTest.call()
     end
   end
 end


### PR DESCRIPTION
This PR adds Service objects and Form objects, which are designed to compliment each other. Together they complete the NForm library, providing everything we need to design apps around callable services.
